### PR TITLE
Fix various piston exploits

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -134,6 +134,12 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("world.settings.block-tree-growth.info", "This setting allows for server owners to easily block trees growing from automatically destroying certain blocks. The list must be a string with numerical item ids separated by commas.");
         generateConfigOption("world.settings.block-pistons-pushing-furnaces.info", "This workaround prevents pistons from pushing furnaces which prevents a malicious server crash.");
         generateConfigOption("world.settings.block-pistons-pushing-furnaces.enabled", true);
+        generateConfigOption("world.settings.pistons.transmutation-fix.enabled", true);
+        generateConfigOption("world.settings.pistons.transmutation-fix.info", "This setting fixes block transmutation exploits.");
+        generateConfigOption("world.settings.pistons.sand-gravel-duping-fix.enabled", true);
+        generateConfigOption("world.settings.pistons.sand-gravel-duping-fix.info", "This setting fixes sand/gravel duplication exploits.");
+        generateConfigOption("world.settings.pistons.other-fixes.enabled", true);
+        generateConfigOption("world.settings.pistons.other-fixes.info", "This setting fixes various other piston exploits like creating illegal pistons, breaking bedrock and duplicating redstone torches.");
         generateConfigOption("world.settings.skeleton-shooting-sound-fix.info", "This setting fixes the sound of skeletons and players shooting not playing on clients.");
         generateConfigOption("world.settings.skeleton-shooting-sound-fix.enabled", true);
         generateConfigOption("world.settings.speed-hack-check.enable", true);

--- a/src/main/java/net/minecraft/server/Block.java
+++ b/src/main/java/net/minecraft/server/Block.java
@@ -299,9 +299,6 @@ public class Block {
 
     public final void g(World world, int i, int j, int k, int l) {
         this.dropNaturally(world, i, j, k, l, 1.0F);
-        if (this instanceof BlockRedstoneTorch) {
-            world.setTypeId(i, j, k, 0);
-        }
     }
 
     public void dropNaturally(World world, int i, int j, int k, int l, float f) {

--- a/src/main/java/net/minecraft/server/Block.java
+++ b/src/main/java/net/minecraft/server/Block.java
@@ -299,6 +299,9 @@ public class Block {
 
     public final void g(World world, int i, int j, int k, int l) {
         this.dropNaturally(world, i, j, k, l, 1.0F);
+        if (this instanceof BlockRedstoneTorch) {
+            world.setTypeId(i, j, k, 0);
+        }
     }
 
     public void dropNaturally(World world, int i, int j, int k, int l, float f) {

--- a/src/main/java/net/minecraft/server/BlockPiston.java
+++ b/src/main/java/net/minecraft/server/BlockPiston.java
@@ -340,7 +340,7 @@ public class BlockPiston extends Block {
                     }
 
                     Block.byId[i2].g(world, i1, j1, k1, world.getData(i1, j1, k1));
-                    world.setTypeId(i1, j1, k1, 0);
+                    world.setRawTypeId(i1, j1, k1, 0);
                 }
             }
 

--- a/src/main/java/net/minecraft/server/BlockPiston.java
+++ b/src/main/java/net/minecraft/server/BlockPiston.java
@@ -340,7 +340,11 @@ public class BlockPiston extends Block {
                     }
 
                     Block.byId[i2].g(world, i1, j1, k1, world.getData(i1, j1, k1));
-                    world.setRawTypeId(i1, j1, k1, 0);
+                    if (PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.other-fixes.enabled", true)) {
+                        world.setRawTypeId(i1, j1, k1, 0);
+                    } else {
+                        world.setTypeId(i1, j1, k1, 0);
+                    }
                 }
             }
 

--- a/src/main/java/net/minecraft/server/BlockPistonExtension.java
+++ b/src/main/java/net/minecraft/server/BlockPistonExtension.java
@@ -16,7 +16,7 @@ public class BlockPistonExtension extends Block {
     public void remove(World world, int i, int j, int k) {
         super.remove(world, i, j, k);
         int l = world.getData(i, j, k);
-        if (l > 5 || l < 0) return; // CraftBukkit - fixed a piston AIOOBE issue.
+        if (l < 0 || l == 6 || l == 7 || l > 13) return; // CraftBukkit - fixed a piston AIOOBE issue.
         int i1 = PistonBlockTextures.a[b(l)];
 
         i += PistonBlockTextures.b[i1];

--- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
@@ -1,5 +1,6 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.event.block.BlockRedstoneEvent;
 
 import java.util.ArrayList;
@@ -62,7 +63,7 @@ public class BlockRedstoneTorch extends BlockTorch {
     }
 
     public void remove(World world, int i, int j, int k) {
-        if (this.isOn && (world.getTypeId(i, j, k) == this.id || world.getTypeId(i, j, k) == 75)) {
+        if (this.isOn && (!PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.transmutation-fix.enabled", true) || world.getTypeId(i, j, k) == this.id || world.getTypeId(i, j, k) == 75)) {
             world.applyPhysics(i, j - 1, k, this.id);
             world.applyPhysics(i, j + 1, k, this.id);
             world.applyPhysics(i - 1, j, k, this.id);

--- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
@@ -63,12 +63,12 @@ public class BlockRedstoneTorch extends BlockTorch {
 
     public void remove(World world, int i, int j, int k) {
         if (this.isOn) {
-            world.applyPhysics(i, j - 1, k, this.id);
-            world.applyPhysics(i, j + 1, k, this.id);
-            world.applyPhysics(i - 1, j, k, this.id);
-            world.applyPhysics(i + 1, j, k, this.id);
-            world.applyPhysics(i, j, k - 1, this.id);
-            world.applyPhysics(i, j, k + 1, this.id);
+            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j - 1, k, this.id);
+            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j + 1, k, this.id);
+            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i - 1, j, k, this.id);
+            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i + 1, j, k, this.id);
+            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j, k - 1, this.id);
+            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j, k + 1, this.id);
         }
     }
 

--- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
@@ -62,13 +62,13 @@ public class BlockRedstoneTorch extends BlockTorch {
     }
 
     public void remove(World world, int i, int j, int k) {
-        if (this.isOn) {
-            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j - 1, k, this.id);
-            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j + 1, k, this.id);
-            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i - 1, j, k, this.id);
-            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i + 1, j, k, this.id);
-            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j, k - 1, this.id);
-            if (world.getTypeId(i, j, k) == this.id) world.applyPhysics(i, j, k + 1, this.id);
+        if (this.isOn && world.getTypeId(i, j, k) == this.id) {
+            world.applyPhysics(i, j - 1, k, this.id);
+            world.applyPhysics(i, j + 1, k, this.id);
+            world.applyPhysics(i - 1, j, k, this.id);
+            world.applyPhysics(i + 1, j, k, this.id);
+            world.applyPhysics(i, j, k - 1, this.id);
+            world.applyPhysics(i, j, k + 1, this.id);
         }
     }
 

--- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
@@ -62,7 +62,7 @@ public class BlockRedstoneTorch extends BlockTorch {
     }
 
     public void remove(World world, int i, int j, int k) {
-        if (this.isOn && world.getTypeId(i, j, k) == this.id) {
+        if (this.isOn && (world.getTypeId(i, j, k) == this.id || world.getTypeId(i, j, k) == 75)) {
             world.applyPhysics(i, j - 1, k, this.id);
             world.applyPhysics(i, j + 1, k, this.id);
             world.applyPhysics(i - 1, j, k, this.id);

--- a/src/main/java/net/minecraft/server/BlockSand.java
+++ b/src/main/java/net/minecraft/server/BlockSand.java
@@ -27,6 +27,7 @@ public class BlockSand extends Block {
             byte b0 = 32;
 
             if (!instaFall && world.a(i - b0, j - b0, k - b0, i + b0, j + b0, k + b0)) {
+                world.setTypeId(i, j, k, 0);
                 EntityFallingSand entityfallingsand = new EntityFallingSand(world, i + 0.5D, j + 0.5D, k + 0.5D, this.id);
 
                 world.addEntity(entityfallingsand);

--- a/src/main/java/net/minecraft/server/BlockSand.java
+++ b/src/main/java/net/minecraft/server/BlockSand.java
@@ -1,5 +1,7 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
+
 import java.util.Random;
 
 public class BlockSand extends Block {
@@ -27,7 +29,9 @@ public class BlockSand extends Block {
             byte b0 = 32;
 
             if (!instaFall && world.a(i - b0, j - b0, k - b0, i + b0, j + b0, k + b0)) {
-                world.setTypeId(i, j, k, 0);
+                if (PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.sand-gravel-duping-fix.enabled", true)) {
+                    world.setTypeId(i, j, k, 0);
+                }
                 EntityFallingSand entityfallingsand = new EntityFallingSand(world, i + 0.5D, j + 0.5D, k + 0.5D, this.id);
 
                 world.addEntity(entityfallingsand);

--- a/src/main/java/net/minecraft/server/BlockTorch.java
+++ b/src/main/java/net/minecraft/server/BlockTorch.java
@@ -1,5 +1,7 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
+
 import java.util.Random;
 
 public class BlockTorch extends Block {
@@ -30,7 +32,7 @@ public class BlockTorch extends Block {
     }
 
     public void postPlace(World world, int i, int j, int k, int l) {
-        if (world.getTypeId(i, j, k) != this.id) return;
+        if (PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.transmutation-fix.enabled", true) && world.getTypeId(i, j, k) != this.id) return;
         int i1 = world.getData(i, j, k);
 
         if (l == 1 && this.g(world, i, j - 1, k)) {
@@ -112,7 +114,7 @@ public class BlockTorch extends Block {
     }
 
     private boolean h(World world, int i, int j, int k) {
-        if (!this.canPlace(world, i, j, k) && world.getTypeId(i, j, k) == this.id) {
+        if (!this.canPlace(world, i, j, k) && (!PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.other-fixes.enabled") || world.getTypeId(i, j, k) == this.id)) {
             this.g(world, i, j, k, world.getData(i, j, k));
             world.setTypeId(i, j, k, 0);
             return false;

--- a/src/main/java/net/minecraft/server/BlockTorch.java
+++ b/src/main/java/net/minecraft/server/BlockTorch.java
@@ -112,7 +112,7 @@ public class BlockTorch extends Block {
     }
 
     private boolean h(World world, int i, int j, int k) {
-        if (!this.canPlace(world, i, j, k)) {
+        if (!this.canPlace(world, i, j, k) && world.getTypeId(i, j, k) == this.id) {
             this.g(world, i, j, k, world.getData(i, j, k));
             world.setTypeId(i, j, k, 0);
             return false;

--- a/src/main/java/net/minecraft/server/BlockTorch.java
+++ b/src/main/java/net/minecraft/server/BlockTorch.java
@@ -30,6 +30,7 @@ public class BlockTorch extends Block {
     }
 
     public void postPlace(World world, int i, int j, int k, int l) {
+        if (world.getTypeId(i, j, k) != this.id) return;
         int i1 = world.getData(i, j, k);
 
         if (l == 1 && this.g(world, i, j - 1, k)) {

--- a/src/main/java/net/minecraft/server/Chunk.java
+++ b/src/main/java/net/minecraft/server/Chunk.java
@@ -1,5 +1,7 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
+
 import java.util.*;
 
 public class Chunk {
@@ -233,9 +235,16 @@ public class Chunk {
             int i2 = this.z * 16 + k;
 
             this.b[i << 11 | k << 7 | j] = (byte) (b0 & 255);
-            this.e.a(i, j, k, i1);
-            if (k1 != 0 && !this.world.isStatic) {
-                Block.byId[k1].remove(this.world, l1, j, i2);
+            if (PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.transmutation-fix.enabled", true)) {
+                this.e.a(i, j, k, i1);
+                if (k1 != 0 && !this.world.isStatic) {
+                    Block.byId[k1].remove(this.world, l1, j, i2);
+                }
+            } else {
+                if (k1 != 0 && !this.world.isStatic) {
+                    Block.byId[k1].remove(this.world, l1, j, i2);
+                }
+                this.e.a(i, j, k, i1);
             }
 
             if (!this.world.worldProvider.e) {

--- a/src/main/java/net/minecraft/server/Chunk.java
+++ b/src/main/java/net/minecraft/server/Chunk.java
@@ -233,11 +233,11 @@ public class Chunk {
             int i2 = this.z * 16 + k;
 
             this.b[i << 11 | k << 7 | j] = (byte) (b0 & 255);
+            this.e.a(i, j, k, i1);
             if (k1 != 0 && !this.world.isStatic) {
                 Block.byId[k1].remove(this.world, l1, j, i2);
             }
 
-            this.e.a(i, j, k, i1);
             if (!this.world.worldProvider.e) {
                 if (Block.q[b0 & 255] != 0) {
                     if (j >= j1) {
@@ -252,7 +252,6 @@ public class Chunk {
 
             this.world.a(EnumSkyBlock.BLOCK, l1, j, i2, l1, j, i2);
             this.c(i, k);
-            this.e.a(i, j, k, i1);
             if (l != 0) {
                 Block.byId[l].c(this.world, l1, j, i2);
             }

--- a/src/main/java/net/minecraft/server/ItemBlock.java
+++ b/src/main/java/net/minecraft/server/ItemBlock.java
@@ -1,6 +1,7 @@
 package net.minecraft.server;
 
 // CraftBukkit start
+import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.craftbukkit.block.CraftBlockState;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -103,7 +104,7 @@ public class ItemBlock extends Item {
                 }
                 // CraftBukkit end
 
-                if (this.id == 29 || this.id == 33) {
+                if (PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.other-fixes.enabled", true) && (this.id == 29 || this.id == 33)) {
                     Block.byId[this.id].postPlace(world, i, j, k, l);
                     Block.byId[this.id].postPlace(world, i, j, k, entityhuman);
                     world.update(i, j, k, this.id); // <-- world.setTypeIdAndData does this on success (tell the world)

--- a/src/main/java/net/minecraft/server/ItemBlock.java
+++ b/src/main/java/net/minecraft/server/ItemBlock.java
@@ -101,6 +101,10 @@ public class ItemBlock extends Item {
                     return true;
 
                 }
+                if (this.id == 29 || this.id == 33) {
+                    Block.byId[this.id].postPlace(world, i, j, k, l);
+                    Block.byId[this.id].postPlace(world, i, j, k, entityhuman);
+                }
                 world.update(i, j, k, this.id); // <-- world.setTypeIdAndData does this on success (tell the world)
 
                 // CraftBukkit end

--- a/src/main/java/net/minecraft/server/ItemBlock.java
+++ b/src/main/java/net/minecraft/server/ItemBlock.java
@@ -1,7 +1,6 @@
 package net.minecraft.server;
 
 // CraftBukkit start
-import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.block.CraftBlockState;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockPlaceEvent;

--- a/src/main/java/net/minecraft/server/ItemBlock.java
+++ b/src/main/java/net/minecraft/server/ItemBlock.java
@@ -1,6 +1,7 @@
 package net.minecraft.server;
 
 // CraftBukkit start
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.block.CraftBlockState;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -101,16 +102,18 @@ public class ItemBlock extends Item {
                     return true;
 
                 }
+                // CraftBukkit end
+
                 if (this.id == 29 || this.id == 33) {
                     Block.byId[this.id].postPlace(world, i, j, k, l);
                     Block.byId[this.id].postPlace(world, i, j, k, entityhuman);
+                    world.update(i, j, k, this.id); // <-- world.setTypeIdAndData does this on success (tell the world)
+                } else {
+                    world.update(i, j, k, this.id);
+                    Block.byId[this.id].postPlace(world, i, j, k, l);
+                    Block.byId[this.id].postPlace(world, i, j, k, entityhuman);
                 }
-                world.update(i, j, k, this.id); // <-- world.setTypeIdAndData does this on success (tell the world)
 
-                // CraftBukkit end
-
-                Block.byId[this.id].postPlace(world, i, j, k, l);
-                Block.byId[this.id].postPlace(world, i, j, k, entityhuman);
                 world.makeSound((double) ((float) i + 0.5F), (double) ((float) j + 0.5F), (double) ((float) k + 0.5F), block.stepSound.getName(), (block.stepSound.getVolume1() + 1.0F) / 2.0F, block.stepSound.getVolume2() * 0.8F);
                 --itemstack.count;
             }


### PR DESCRIPTION
This pull request encompasses fixes for the following exploits:

- [Moving Piston Merge Transmutation](https://mcdf.wiki.gg/wiki/Java_Edition:Block_Transmutation#Moving_Piston_Merge_Transmutation)
- [Water Transmutation](https://mcdf.wiki.gg/wiki/Java_Edition:Block_Transmutation#Liquid_Transmutation)
- [Another type of Transmutation](https://www.youtube.com/watch?v=XIfam26fOvE)
- [Methods to obtain illegal pistons](https://www.youtube.com/watch?v=eghYMVVOrbc)
- [Methods to remove unbreakable blocks](https://mcdf.wiki.gg/wiki/Java_Edition:Unbreakable_Block_Removal_Methods#Beta_1.7_Pistons)
- [Methods to dupe redstone torches and sand/gravel](https://www.youtube.com/watch?v=7AE126Y9Ej8)
- and probably some other exploits as well

### PLEASE CONDUCT TESTING!

I have done some testing and found that the exploits were in fact patched, however I could've missed some methods to reproduce them or made an oversight while patching them, causing other things to break.

### If you know of any other piston exploits that need fixing, please let me know!