### PR TITLE
Resolve issues with Event IgnoreCancelled annotation being ignored

### DIFF
--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -1,5 +1,6 @@
 package org.bukkit.plugin;
 
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.Listener;
 
@@ -11,19 +12,22 @@ public class RegisteredListener {
     private final Event.Priority priority;
     private final Plugin plugin;
     private final EventExecutor executor;
+    private final boolean ignoreCancelled;
 
     public RegisteredListener(final Listener pluginListener, final EventExecutor eventExecutor, final Event.Priority eventPriority, final Plugin registeredPlugin) {
-        listener = pluginListener;
-        priority = eventPriority;
-        plugin = registeredPlugin;
-        executor = eventExecutor;
+        this(pluginListener, eventExecutor, eventPriority, registeredPlugin, false);
+    }
+
+    public RegisteredListener(final Listener pluginListener, final EventExecutor eventExecutor, final Event.Priority eventPriority, final Plugin registeredPlugin, final boolean ignoreCancelled) {
+        this.listener = pluginListener;
+        this.priority = eventPriority;
+        this.plugin = registeredPlugin;
+        this.executor = eventExecutor;
+        this.ignoreCancelled = ignoreCancelled;
     }
 
     public RegisteredListener(final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin, Event.Type type) {
-        listener = pluginListener;
-        priority = eventPriority;
-        plugin = registeredPlugin;
-        executor = registeredPlugin.getPluginLoader().createExecutor(type, pluginListener);
+        this(pluginListener, registeredPlugin.getPluginLoader().createExecutor(type, pluginListener), eventPriority, registeredPlugin, false);
     }
 
     public void registerAll() {
@@ -59,6 +63,11 @@ public class RegisteredListener {
      * @return Registered Priority
      */
     public void callEvent(Event event) {
+        if(event instanceof Cancellable) {
+            if(((Cancellable) event).isCancelled() && ignoreCancelled) {
+                return;
+            }
+        }
         executor.execute(listener, event);
     }
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -272,7 +272,7 @@ public class JavaPluginLoader implements PluginLoader
                     e.printStackTrace();
                 }
             };
-            eventSet.add(new RegisteredListener(listener, executor, eh.priority(), plugin));
+            eventSet.add(new RegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
         }
         return ret;
     }


### PR DESCRIPTION
Ensure the server adhears to the ignoreCancelled (`@EventHandler(priority = Event.Priority.Monitor, ignoreCancelled = true)`) annotation for listeners.

This code has been tested and verified utilizing the following code.
`    @EventHandler(priority = Event.Priority.Monitor, ignoreCancelled = true)
    public void monitorChatEvent(PlayerChatEvent event) {
        // Print the message to the console with the priority

        if(event.isCancelled()) {
            logger(Level.INFO, "Monitor: " + event.getMessage() + ". This should not be printed as this listener is set to ignore cancelled events.");
        } else {
            logger(Level.INFO, "Monitor: " + event.getMessage());
        }
    }

    @EventHandler(priority = Event.Priority.Normal, ignoreCancelled = false)
    public void normalChatEvent(PlayerChatEvent event) {
        // Print the message to the console with the priority
        logger(Level.INFO, "Normal: " + event.getMessage());

        // 50% chance to cancel the event
        if (Math.random() < 0.5) {
            System.out.println("Cancelling event");
            event.setCancelled(true);
        }
    }`

Without Patch
![image](https://github.com/user-attachments/assets/c1d68d1a-ec95-455b-a321-c10aad9988e4)

With Patch
![image](https://github.com/user-attachments/assets/8f56579d-6356-45b8-9913-70b0061ec19e)
