### PR TITLE
Implement Boat Crash Exploit Mitigation from UberBukkit

### DIFF
--- a/src/main/java/net/minecraft/server/NetServerHandler.java
+++ b/src/main/java/net/minecraft/server/NetServerHandler.java
@@ -285,6 +285,19 @@ public class NetServerHandler extends NetHandler implements ICommandListener {
                 if (packet10flying.h && packet10flying.y == -999.0D && packet10flying.stance == -999.0D) {
                     d5 = packet10flying.x;
                     d4 = packet10flying.z;
+
+                    // Project Poseidon - Start
+                    // Boat crash fix ported from UberBukkit
+
+                    double d8 = d5 * d5 + d4 * d4;
+                    if (d8 > 100.0D) {
+                        a.warning("[Poseidon]" + this.player.name + " tried crashing server on entity " + this.player.vehicle.toString() + ". They have been kicked.");
+                        player.kickPlayer("Boat crash attempt detected!");
+                        return;
+                    }
+
+                    // Project Poseidon - End
+
                 }
 
                 this.player.onGround = packet10flying.g;


### PR DESCRIPTION
Resolve an exploit where a player could use a vehicle (such as a boat or minecart) to send packets with abnormally large movement values which can cause lag, hangs, or crashes. 

**Fix Explanation:**
- Added a displacement check (`d5 * d5 + d4 * d4 > 100.0D`) in the `Packet10Flying` handler for players in vehicles.
- If the threshold is exceeded, the player is kicked to prevent server crashes.
- Logs the incident for administrator review with details about the player and vehicle.

**Changes:**
- Logs and mitigates invalid movement packets during vehicle usage.
- Kicks offending players with the message: *"Boat crash attempt detected!"*.
