### PR TITLE
Add Version Update Checker and Refactor Poseidon Elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.bukkit</groupId>
     <artifactId>project-poseidon</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.8</version>
+    <version>1.1.10</version>
     <name>Project Poseidon</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/legacyminecraft/poseidon/Poseidon.java
+++ b/src/main/java/com/legacyminecraft/poseidon/Poseidon.java
@@ -1,11 +1,13 @@
 package com.legacyminecraft.poseidon;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 import org.bukkit.craftbukkit.CraftServer;
 
 import java.util.LinkedList;
 
-public class Poseidon {
+public final class Poseidon {
+    private static PoseidonServer server;
 
     /**
      * Returns a list of the server's TPS (Ticks Per Second) records for performance monitoring.
@@ -15,6 +17,18 @@ public class Poseidon {
      */
     public static LinkedList<Double> getTpsRecords() {
         return ((CraftServer) Bukkit.getServer()).getServer().getTpsRecords();
+    }
+
+    public static PoseidonServer getServer() {
+        return server;
+    }
+
+    public static void setServer(PoseidonServer server) {
+        if (Poseidon.server != null) {
+            throw new UnsupportedOperationException("Cannot redefine singleton Server");
+        }
+
+        Poseidon.server = server;
     }
 
 

--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -30,7 +30,7 @@ public class PoseidonConfig extends Configuration {
 
     public void resetConfig() {
         // Delete all the config options
-        for(String key : this.getKeys()) {
+        for (String key : this.getKeys()) {
             this.removeProperty(key);
         }
         // Reload the config
@@ -95,7 +95,7 @@ public class PoseidonConfig extends Configuration {
 
         generateConfigOption("settings.fix-drowning-push-down.enabled", true);
         generateConfigOption("settings.fix-drowning-push-down.info", "This setting fixes taking drowning damage pushing you down.");
-        
+
         generateConfigOption("settings.player-knockback-fix.enabled", true);
         generateConfigOption("settings.player-knockback-fix.info", "This setting fixes reduced knockback for certain players on the server.");
 
@@ -179,6 +179,11 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("emergency.debug.regenerate-corrupt-chunks.enable", false);
         generateConfigOption("emergency.debug.regenerate-corrupt-chunks.info", "This setting allows you to automatically regenerate corrupt chunks. This is useful after a ungraceful shutdown while a file is being written to or out of memory exception.");
 
+        generateConfigOption("settings.update-checker.enabled", true);
+        generateConfigOption("settings.update-checker.info", "This setting allows you to disable the update checker. This is useful if you have a custom build of Poseidon or don't want to be notified of updates.");
+        generateConfigOption("settings.update-checker.notify-staff.enabled", true);
+        generateConfigOption("settings.update-checker.notify-staff.info", "This setting notifies operators and players with the permission poseidon.update when a new version of Poseidon is available on join.");
+
         //Messages
         generateConfigOption("message.kick.banned", "You are banned from this server!");
         generateConfigOption("message.kick.ip-banned", "Your IP address is banned from this server!");
@@ -188,6 +193,7 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("message.kick.already-online", "\u00A7cA player with your username or uuid is already online, try reconnecting in a minute.");
         generateConfigOption("message.player.join", "\u00A7e%player% joined the game.");
         generateConfigOption("message.player.leave", "\u00A7e%player% left the game.");
+        generateConfigOption("message.update.available", "\u00A7dA newer version of Poseidon is available: %newversion%");
 
         //Optional Poseidon Commands
         generateConfigOption("command.info", "This section allows you to enable or disable optional Poseidon commands. This is useful if you have a plugin that conflicts with a Poseidon command.");

--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
@@ -1,0 +1,200 @@
+package com.legacyminecraft.poseidon;
+
+import com.legacyminecraft.poseidon.utility.PoseidonVersionChecker;
+import com.legacyminecraft.poseidon.watchdog.WatchDogThread;
+import com.projectposeidon.johnymuffin.UUIDManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.NetServerHandler;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.CraftServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public final class PoseidonServer {
+    private final MinecraftServer server;
+    private final CraftServer craftServer;
+
+    private final List<String> hiddenCommands = new ArrayList<>();
+    private final Properties versionProperties = new Properties();
+
+    private boolean serverInitialized = false;
+
+    private PoseidonVersionChecker poseidonVersionChecker;
+    private WatchDogThread watchDogThread;
+
+    public PoseidonServer(MinecraftServer server, CraftServer craftServer) {
+        this.server = server;
+        this.craftServer = craftServer;
+
+        loadVersionProperties();
+
+        addHiddenCommands(Arrays.asList("login", "l", "register", "reg", "unregister", "changepassword", "changepw"));
+    }
+
+    private void loadVersionProperties() {
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("version.properties")) {
+            if (inputStream != null) {
+                versionProperties.load(inputStream);
+            }
+        } catch (IOException e) {
+            getLogger().warning("Failed to load version.properties: " + e.getMessage());
+        }
+    }
+
+    public void initializeServer() {
+        if (serverInitialized) {
+            throw new UnsupportedOperationException("Server already initialized");
+        }
+
+        getLogger().info("[Poseidon] Starting Project Poseidon Modules!");
+
+        PoseidonConfig.getInstance();
+        UUIDManager.getInstance();
+
+        initializeUpdateChecker();
+
+        //Start Watchdog
+        watchDogThread = new WatchDogThread(Thread.currentThread());
+        if (PoseidonConfig.getInstance().getBoolean("settings.enable-watchdog", true)) {
+            getLogger().info("[Poseidon] Starting Watchdog to detect any server hangs!");
+            watchDogThread.start();
+            watchDogThread.tickUpdate();
+        }
+
+        serverInitialized = true;
+        getLogger().info("[Poseidon] Finished loading Project Poseidon Modules!");
+    }
+
+    private void initializeUpdateChecker() {
+        if (!PoseidonConfig.getInstance().getConfigBoolean("settings.update-checker.enabled", true)) {
+            getLogger().info("[Poseidon] Version checker disabled. The server will not check for updates.");
+            return;
+        }
+
+        String releaseVersion = getReleaseVersion();
+
+        if (releaseVersion == null) {
+            getLogger().warning("[Poseidon] Version checker is disabled as no version.properties file was found.");
+            return;
+        }
+
+        if(!getBuildType().equalsIgnoreCase("production")) {
+            getLogger().warning("[Poseidon] Version checker is disabled as this is a " + getBuildType() + " build. The updater will only check for updates on production builds.");
+            return;
+        }
+
+        poseidonVersionChecker = new PoseidonVersionChecker(craftServer, releaseVersion);
+
+        getLogger().info("[Poseidon] Version checker enabled. The server will check for updates every hour.");
+        // Run the version checker in a separate thread every hour
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(new PoseidonPlugin(), new Runnable() {
+            @Override
+            public void run() {
+                poseidonVersionChecker.fetchLatestVersion();
+            }
+        }, 0, 20 * 60 * 60);
+    }
+
+    public void shutdownServer() {
+        if (!serverInitialized) {
+            throw new UnsupportedOperationException("Server not initialized");
+        }
+
+        getLogger().info("[Poseidon] Stopping Project Poseidon Modules!");
+
+        UUIDManager.getInstance().saveJsonArray();
+
+        if (watchDogThread != null) {
+            getLogger().info("[Poseidon] Stopping Watchdog!");
+            watchDogThread.interrupt();
+        }
+
+        serverInitialized = false;
+        getLogger().info("[Poseidon] Finished unloading Project Poseidon Modules!");
+    }
+
+    public Logger getLogger() {
+        return MinecraftServer.log;
+    }
+
+    public String getAppName() {
+        return versionProperties.getProperty("app_name", "Unknown");
+    }
+
+    public String getReleaseVersion() {
+        return versionProperties.getProperty("release_version", "Unknown");
+    }
+
+    public String getMavenVersion() {
+        return versionProperties.getProperty("maven_version", "Unknown");
+    }
+
+    public String getBuildTimestamp() {
+        return versionProperties.getProperty("build_timestamp", "Unknown");
+    }
+
+    public String getGitCommit() {
+        return versionProperties.getProperty("git_commit", "Unknown");
+    }
+
+    public String getBuildType() {
+        return versionProperties.getProperty("build_type", "Unknown");
+    }
+
+    public boolean isUpdateAvailable() {
+        return poseidonVersionChecker != null && poseidonVersionChecker.isUpdateAvailable();
+    }
+
+    public String getNewestVersion() {
+        return poseidonVersionChecker == null ? "Unknown" : poseidonVersionChecker.getLatestVersion();
+    }
+
+    public WatchDogThread getWatchDogThread() {
+        return watchDogThread;
+    }
+
+    /**
+     * Returns the current hide state of the command from param (Hide from console)
+     *
+     * @param cmdName Command name
+     * @return True if the command from param is hidden and false otherwise
+     */
+    public boolean isCommandHidden(String cmdName) {
+        return hiddenCommands.contains(cmdName.toLowerCase());
+    }
+
+
+    /**
+     * Hides the command from param from being logged to server console
+     *
+     * @param cmd Command name
+     */
+    public void addHiddenCommand(String cmd) {
+        cmd = cmd.toLowerCase();
+
+        if (hiddenCommands.contains(cmd)) {
+            Logger.getLogger(NetServerHandler.class.getName()).warning("List of Hidden commands already contains " + cmd);
+            return;
+        }
+
+        hiddenCommands.add(cmd);
+    }
+
+    /**
+     * Hides the commands from param from being logged to server console
+     *
+     * @param commands List of command names
+     */
+    public void addHiddenCommands(List<String> commands) {
+        for (String cmd : commands) {
+            addHiddenCommand(cmd);
+        }
+    }
+
+}

--- a/src/main/java/com/legacyminecraft/poseidon/commands/PoseidonCommand.java
+++ b/src/main/java/com/legacyminecraft/poseidon/commands/PoseidonCommand.java
@@ -1,5 +1,6 @@
 package com.legacyminecraft.poseidon.commands;
 
+import com.legacyminecraft.poseidon.Poseidon;
 import com.projectposeidon.api.PoseidonUUID;
 import com.projectposeidon.api.UUIDType;
 import org.bukkit.Bukkit;
@@ -22,28 +23,17 @@ public class PoseidonCommand extends Command {
         this.description = "Show data regarding the server's version of Project Poseidon";
         this.usageMessage = "/poseidon";
         this.setAliases(Arrays.asList("projectposeidon"));
-        loadVersionProperties();
-    }
-
-    private void loadVersionProperties() {
-        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("version.properties")) {
-            if (inputStream != null) {
-                versionProperties.load(inputStream);
-            }
-        } catch (IOException e) {
-            Bukkit.getLogger().warning("Failed to load version.properties: " + e.getMessage());
-        }
     }
 
     @Override
     public boolean execute(CommandSender sender, String currentAlias, String[] args) {
         if (args.length == 0) {
-            String appName = versionProperties.getProperty("app_name", "Unknown");
-            String releaseVersion = versionProperties.getProperty("release_version", "Unknown");
-            String mavenVersion = versionProperties.getProperty("maven_version", "Unknown");
-            String buildTimestamp = versionProperties.getProperty("build_timestamp", "Unknown");
-            String gitCommit = versionProperties.getProperty("git_commit", "Unknown");
-            String buildType = versionProperties.getProperty("build_type", "Unknown");
+            String appName = Poseidon.getServer().getAppName();
+            String releaseVersion = Poseidon.getServer().getReleaseVersion();
+            String mavenVersion = Poseidon.getServer().getMavenVersion();
+            String buildTimestamp = Poseidon.getServer().getBuildTimestamp();
+            String gitCommit = Poseidon.getServer().getGitCommit();
+            String buildType = Poseidon.getServer().getBuildType();
 
             // Shorten the git commit hash to 7 characters
             if (gitCommit.length() > 7) {

--- a/src/main/java/com/legacyminecraft/poseidon/utility/PoseidonVersionChecker.java
+++ b/src/main/java/com/legacyminecraft/poseidon/utility/PoseidonVersionChecker.java
@@ -1,0 +1,94 @@
+package com.legacyminecraft.poseidon.utility;
+
+import org.bukkit.craftbukkit.CraftServer;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+public class PoseidonVersionChecker {
+
+    private static final String GITHUB_API_URL = "https://api.github.com/repos/retromcorg/Project-Poseidon/releases/latest";
+    private static final String releaseUrl = "https://github.com/retromcorg/Project-Poseidon/releases";
+    private final String currentVersion;
+    private volatile String latestVersion;
+    private CraftServer server;
+
+    public PoseidonVersionChecker(CraftServer server, String currentVersion) {
+        this.currentVersion = currentVersion;
+        this.latestVersion = currentVersion; // Assume the latest version is the current version until checked
+        this.server = server;
+    }
+
+    /**
+     * Checks if a new version is available.
+     *
+     * @return true if a newer version is available, false otherwise.
+     */
+    public synchronized boolean isUpdateAvailable() {
+        return latestVersion != null && !currentVersion.equalsIgnoreCase(latestVersion);
+    }
+
+    /**
+     * Fetches the latest release version from GitHub API.
+     *
+     * @return the latest version as a String or null if fetching fails.
+     */
+    public void fetchLatestVersion() {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(GITHUB_API_URL);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                server.getLogger().log(Level.WARNING, "[Poseidon] Failed to check GitHub for latest version. HTTP Response Code: " + responseCode);
+            }
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            StringBuilder response = new StringBuilder();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                response.append(line);
+            }
+            reader.close();
+
+            JSONParser parser = new JSONParser();
+            JSONObject json = (JSONObject) parser.parse(response.toString());
+
+            this.latestVersion = (String) json.get("tag_name");
+
+            if (isUpdateAvailable()) {
+                server.getLogger().log(Level.INFO, "[Poseidon] A new version is available: " + latestVersion);
+                server.getLogger().log(Level.INFO, "[Poseidon] You are currently running version: " + currentVersion);
+                server.getLogger().log(Level.INFO, "[Poseidon] Download the latest version here: " + releaseUrl);
+            } else {
+                server.getLogger().log(Level.INFO, "[Poseidon] You are running the latest version (" + currentVersion + ") of Project Poseidon.");
+            }
+        } catch (Exception e) {
+            server.getLogger().log(Level.WARNING, "[Poseidon] Failed to check GitHub for latest version.", e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    public String getCurrentVersion() {
+        return currentVersion;
+    }
+
+    public String getLatestVersion() {
+        return latestVersion;
+    }
+}

--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -1,11 +1,15 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.Poseidon;
 import com.legacyminecraft.poseidon.PoseidonConfig;
+import com.legacyminecraft.poseidon.PoseidonPlugin;
 import com.legacyminecraft.poseidon.util.ServerLogRotator;
+import com.legacyminecraft.poseidon.utility.PoseidonVersionChecker;
 import com.projectposeidon.johnymuffin.UUIDManager;
 import com.legacyminecraft.poseidon.watchdog.WatchDogThread;
 import jline.ConsoleReader;
 import joptsimple.OptionSet;
+import org.bukkit.Bukkit;
 import org.bukkit.World.Environment;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.LoggerOutputStream;
@@ -64,8 +68,9 @@ public class MinecraftServer implements Runnable, ICommandListener {
     // CraftBukkit end
 
     //Poseidon Start
-    private WatchDogThread watchDogThread;
+//    private WatchDogThread watchDogThread;
     private boolean modLoaderSupport = false;
+//    private PoseidonVersionChecker poseidonVersionChecker;
     //Poseidon End
 
     public MinecraftServer(OptionSet options) { // CraftBukkit - adds argument OptionSet
@@ -96,7 +101,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
         // CraftBukkit end
 
         //If Poseidon Config DEBUG is enabled, enable debug mode
-        if(options.has("debug-config")) {
+        if (options.has("debug-config")) {
             log.info("[Poseidon] Configuration debug mode has been enabled. This will cause the poseidon.yml to be reloaded every time the server starts.");
             PoseidonConfig.getInstance().resetConfig();
         }
@@ -171,26 +176,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
         this.a(new WorldLoaderServer(new File(".")), s1, k);
 
         //Project Poseidon Start
-        log.info("[Poseidon] Starting Project Poseidon Modules!");
-
-        PoseidonConfig.getInstance();
-        UUIDManager.getInstance();
-
-        //Start Watchdog
-        watchDogThread = new WatchDogThread(Thread.currentThread());
-        if (PoseidonConfig.getInstance().getBoolean("settings.enable-watchdog", true)) {
-            log.info("[Poseidon] Starting Watchdog to detect any server hangs!");
-            watchDogThread.start();
-            watchDogThread.tickUpdate();
-        }
-        //Start Poseidon Statistics
-        if (PoseidonConfig.getInstance().getBoolean("settings.settings.statistics.enabled", true)) {
-//            new PoseidonStatisticsAgent(this, this.server);
-        } else {
-            log.info("[Poseidon] Please consider enabling statistics in Poseidon.yml. It helps us see how many servers are running Poseidon, and what versions.");
-        }
-
-        log.info("[Poseidon] Finished loading Project Poseidon Modules!");
+        Poseidon.getServer().initializeServer();
         //Project Poseidon End
 
         // CraftBukkit start
@@ -372,11 +358,10 @@ public class MinecraftServer implements Runnable, ICommandListener {
         log.info("Stopping server");
 
         //Project Poseidon Start
-        UUIDManager.getInstance().saveJsonArray();
-        if (watchDogThread != null) {
-            log.info("Stopping Poseidon Watchdog");
-            watchDogThread.interrupt();
-        }
+
+        // This is done before disablePlugins() to ensure the watchdog doesn't detect plugins disabling as a server hang
+        Poseidon.getServer().shutdownServer();
+
         //Project Poseidon End
 
         // CraftBukkit start
@@ -433,7 +418,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
                     } else {
                         while (j > 50L) {
                             MinecraftServer.currentTick = (int) (System.currentTimeMillis() / 50); // CraftBukkit
-                            watchDogThread.tickUpdate(); // Project Poseidon
+                            getWatchdog().tickUpdate(); // Project Poseidon
                             j -= 50L;
                             this.h();
                         }
@@ -520,7 +505,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
         if (currentTime - lastTick >= 1000) {
             double tps = tickCount / ((currentTime - lastTick) / 1000.0);
             tpsRecords.addFirst(tps);
-            if(tpsRecords.size() > 900) { //Don't keep more than 15 minutes of data
+            if (tpsRecords.size() > 900) { //Don't keep more than 15 minutes of data
                 tpsRecords.removeLast();
             }
 
@@ -531,7 +516,6 @@ public class MinecraftServer implements Runnable, ICommandListener {
         //Project Poseidon End - Tick Update
 
 
-
         for (j = 0; j < this.worlds.size(); ++j) { // CraftBukkit
             // if (j == 0 || this.propertyManager.getBoolean("allow-nether", true)) { // CraftBukkit
             WorldServer worldserver = this.worlds.get(j); // CraftBukkit
@@ -540,7 +524,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
                 // CraftBukkit start - only send timeupdates to the people in that world
                 for (int i = 0; i < worldserver.players.size(); ++i) { // Project Poseidon: serverConfigurationManager -> worldserver.players
                     EntityPlayer entityPlayer = (EntityPlayer) worldserver.players.get(i);
-                    if(entityPlayer != null) {
+                    if (entityPlayer != null) {
                         entityPlayer.netServerHandler.sendPacket(new Packet4UpdateTime(entityPlayer.getPlayerTime())); // Add support for per player time
 
                     }
@@ -652,6 +636,6 @@ public class MinecraftServer implements Runnable, ICommandListener {
     }
 
     public WatchDogThread getWatchdog() {
-        return this.watchDogThread;
+        return Poseidon.getServer().getWatchDogThread();
     }
 }

--- a/src/main/java/net/minecraft/server/NetServerHandler.java
+++ b/src/main/java/net/minecraft/server/NetServerHandler.java
@@ -1,5 +1,7 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.Poseidon;
+import com.legacyminecraft.poseidon.PoseidonServer;
 import com.legacyminecraft.poseidon.event.PlayerSendPacketEvent;
 import com.projectposeidon.ConnectionType;
 import com.legacyminecraft.poseidon.PoseidonConfig;
@@ -98,6 +100,7 @@ public class NetServerHandler extends NetHandler implements ICommandListener {
     public int getRawConnectionType() {
         return this.rawConnectionType;
     }
+
 
     //Project Poseidon - End
 
@@ -849,7 +852,7 @@ public class NetServerHandler extends NetHandler implements ICommandListener {
                 //Hide commands from being logged in console
                 String cmdName = s.split(" ")[0].replaceAll("/", "");
 
-                if (server.isCommandHidden(cmdName)) {
+                if (Poseidon.getServer().isCommandHidden(cmdName)) {
                     a.info(player.getName() + " issued server command: COMMAND REDACTED");
                 } else {
                     a.info(player.getName() + " issued server command: " + s);

--- a/src/main/java/net/minecraft/server/ServerConfigurationManager.java
+++ b/src/main/java/net/minecraft/server/ServerConfigurationManager.java
@@ -1,5 +1,6 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.Poseidon;
 import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -120,7 +121,8 @@ public class ServerConfigurationManager {
         }
 
         // CraftBukkit start
-        PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(this.cserver.getPlayer(entityplayer), msgPlayerJoin.replace("%player%", entityplayer.name));
+        Player player = this.cserver.getPlayer(entityplayer);
+        PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(player, msgPlayerJoin.replace("%player%", entityplayer.name));
         this.cserver.getPluginManager().callEvent(playerJoinEvent);
 
         String joinMessage = playerJoinEvent.getJoinMessage();
@@ -129,6 +131,18 @@ public class ServerConfigurationManager {
             this.server.serverConfigurationManager.sendAll(new Packet3Chat(joinMessage));
         }
         // CraftBukkit end
+
+        // Poseidon Start
+        // Notify staff of Poseidon update if they are op or have poseidon.update permission
+        if(PoseidonConfig.getInstance().getConfigBoolean("settings.update-checker.notify-staff.enabled", true) && Poseidon.getServer().isUpdateAvailable()) {
+            if (player.isOp() || player.hasPermission("poseidon.update")) {
+                String updateMessage = PoseidonConfig.getInstance().getConfigString("message.update.available");
+                updateMessage = updateMessage.replace("%newversion%", Poseidon.getServer().getNewestVersion());
+                updateMessage = updateMessage.replace("%currentversion%", Poseidon.getServer().getReleaseVersion());
+                player.sendMessage(updateMessage);
+            }
+        }
+        // Poseidon End
 
         worldserver.addEntity(entityplayer);
         this.getPlayerManager(entityplayer.dimension).addPlayer(entityplayer);

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -468,25 +468,4 @@ public interface Server {
      */
     public Set<OfflinePlayer> getBannedPlayers();
 
-    /**
-     * Returns the current hide state of the command from param (Hide from console)
-     *
-     * @param cmdName Command name
-     * @return True if the command from param is hidden and false otherwise
-     */
-    public boolean isCommandHidden(String cmdName);
-
-    /**
-     * Hides the command from param from being logged to server console
-     *
-     * @param cmd Command name
-     */
-    public void addHiddenCommand(String cmd);
-
-    /**
-     * Hides the commands from param from being logged to server console
-     *
-     * @param commands List of command names
-     */
-    public void addHiddenCommands(List<String> commands);
 }

--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -4,6 +4,11 @@ import com.avaje.ebean.config.DataSourceConfig;
 import com.avaje.ebean.config.ServerConfig;
 import com.avaje.ebean.config.dbplatform.SQLitePlatform;
 import com.avaje.ebeaninternal.server.lib.sql.TransactionIsolation;
+import com.legacyminecraft.poseidon.Poseidon;
+import com.legacyminecraft.poseidon.PoseidonConfig;
+import com.legacyminecraft.poseidon.PoseidonPlugin;
+import com.legacyminecraft.poseidon.PoseidonServer;
+import com.legacyminecraft.poseidon.utility.PoseidonVersionChecker;
 import jline.ConsoleReader;
 import net.minecraft.server.*;
 import org.bukkit.Bukkit;
@@ -55,7 +60,7 @@ public final class CraftServer implements Server {
     private final String serverName = "Project Poseidon Craftbukkit";
     //Poseidon Versions
     private final String serverEnvironment = "POSEIDON";
-    private final String serverVersion = "1.1.8";
+    private final String serverVersion = "1.1.10";
     private final String releaseType = "DEVELOPMENT";
     private final String protocolVersion = "1.7.3";
     private final String GameVersion = "b1.7.3";
@@ -78,16 +83,17 @@ public final class CraftServer implements Server {
 
         Bukkit.setServer(this);
 
+        //Project Poseidon Start
+        PoseidonServer poseidonServer = new PoseidonServer(console, this);
+        Poseidon.setServer(poseidonServer);
+        //Project Poseidon End
+
         configuration = new Configuration((File) console.options.valueOf("bukkit-settings"));
         loadConfig();
         loadPlugins();
         enablePlugins(PluginLoadOrder.STARTUP);
 
         ChunkCompressionThread.startThread();
-
-        // Project Poseidon start
-        addHiddenCommands(Arrays.asList("login", "l", "register", "reg", "unregister", "changepassword", "changepw"));
-        // Project Poseidon end
     }
 
     private void loadConfig() {
@@ -852,27 +858,6 @@ public final class CraftServer implements Server {
 
     public void setShuttingdown(boolean shuttingdown) {
         this.shuttingdown = shuttingdown;
-    }
-
-    public boolean isCommandHidden(String cmdName) {
-        return hiddenCommands.contains(cmdName.toLowerCase());
-    }
-
-    public void addHiddenCommand(String cmd) {
-        cmd = cmd.toLowerCase();
-
-        if(hiddenCommands.contains(cmd)) {
-            Logger.getLogger(NetServerHandler.class.getName()).warning("List of Hidden commands already contains " + cmd);
-            return;
-        }
-
-        hiddenCommands.add(cmd);
-    }
-
-    public void addHiddenCommands(List<String> commands) {
-        for(String cmd : commands) {
-            addHiddenCommand(cmd);
-        }
     }
 
 //    public GameMode getDefaultGameMode() {

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -2,6 +2,7 @@ package org.bukkit.plugin;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
+import com.legacyminecraft.poseidon.Poseidon;
 import com.legacyminecraft.poseidon.event.PoseidonCustomListener;
 import org.bukkit.Server;
 import org.bukkit.command.Command;
@@ -290,12 +291,14 @@ public final class SimplePluginManager implements PluginManager {
             if (!pluginCommands.isEmpty()) {
                 commandMap.registerAll(plugin.getDescription().getName(), pluginCommands);
 
+                // Project Poseidon - Start - Hide commands
                 for(Command c : pluginCommands) {
                     if(c.isHidden()) {
-                        server.addHiddenCommand(c.getLabel());
-                        server.addHiddenCommands(c.getAliases());
+                        Poseidon.getServer().addHiddenCommand(c.getLabel());
+                        Poseidon.getServer().addHiddenCommands(c.getAliases());
                     }
                 }
+                // Project Poseidon - End - Hide commands
             }
             
             try {


### PR DESCRIPTION
## Changes in this Pull Request

### 1. Version Increment
- Update Poseidon version to `1.0.10`.
- Note: `1.0.9` was used internally by RetroMC, while the public version has remained at `1.0.8` since 2020.

### 2. Version Update Checker Feature
- Added functionality to automatically check GitHub for newer Poseidon versions.
  - If a newer version is available:
    - Log a message to the server console.
    - Notify staff members upon login.

### 3. Code Refactor
- Refactored significant portions of Poseidon code from `MinecraftServer.java` and `CraftServer.java` into `Poseidon.java` and `PoseidonServer.java`.
- This improves code separation and enhances the overall readability and maintainability of the codebase.