### PR TITLE
[WIP] Chunk compression improvements.

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -169,6 +169,9 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("world.settings.mob-spawner-area-limit.chunk-radius", 8);
         generateConfigOption("world.settings.mob-spawner-area-limit.info",
                 "This setting controls the maximum number of entities of a mob spawner type that can exist within the defined chunk radius around a mob spawner. If the number of entities exceeds this limit, the spawner will stop spawning additional entities of that type. This is useful to stop the extreme lag that can be caused by mob spawners.");
+        generateConfigOption("world.settings.compression.level", "deflate");
+        generateConfigOption("world.settings.compression.info",
+                "Allows changing the compression applied to world chunks. Possible values are \"none\", \"deflate\", and \"gzip\".");
 
         //generateConfigOption("world-settings.eject-from-vehicle-on-teleport.enabled", true);
         //generateConfigOption("world-settings.eject-from-vehicle-on-teleport.info", "Eject the player from a boat or minecart before teleporting them preventing cross world coordinate exploits.");
@@ -222,7 +225,7 @@ public class PoseidonConfig extends Configuration {
 
         //Developer options
         generateConfigOption("developer.region-transaction-logs.enable", false);
-        generateConfigOption("developer.region-transaction-logs", "Enables region transaction logs. Very useful for developers trying to work on the region format, not at all useful for most end-users. Logs a LOT of data.");
+        generateConfigOption("developer.region-transaction-logs.info", "Enables region transaction logs. Very useful for developers trying to work on the region format, not at all useful for most end-users. Logs a LOT of data.");
 
         //Tree Leave Destroy Blacklist
         if (Boolean.valueOf(String.valueOf(getConfigOption("world.settings.block-tree-growth.enabled", true)))) {

--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -170,7 +170,6 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("world.settings.mob-spawner-area-limit.info",
                 "This setting controls the maximum number of entities of a mob spawner type that can exist within the defined chunk radius around a mob spawner. If the number of entities exceeds this limit, the spawner will stop spawning additional entities of that type. This is useful to stop the extreme lag that can be caused by mob spawners.");
 
-
         //generateConfigOption("world-settings.eject-from-vehicle-on-teleport.enabled", true);
         //generateConfigOption("world-settings.eject-from-vehicle-on-teleport.info", "Eject the player from a boat or minecart before teleporting them preventing cross world coordinate exploits.");
 
@@ -220,6 +219,10 @@ public class PoseidonConfig extends Configuration {
         //UberBukkit
         generateConfigOption("fix.optimize-sponges.enabled", true);
         generateConfigOption("fix.optimize-sponges.info", "Optimizes sponges by removing unnecessary block updates. This can also prevent some block duplication methods.");
+
+        //Developer options
+        generateConfigOption("developer.region-transaction-logs.enable", false);
+        generateConfigOption("developer.region-transaction-logs", "Enables region transaction logs. Very useful for developers trying to work on the region format, not at all useful for most end-users. Logs a LOT of data.");
 
         //Tree Leave Destroy Blacklist
         if (Boolean.valueOf(String.valueOf(getConfigOption("world.settings.block-tree-growth.enabled", true)))) {

--- a/src/main/java/com/legacyminecraft/poseidon/level/ChunkCompressionType.java
+++ b/src/main/java/com/legacyminecraft/poseidon/level/ChunkCompressionType.java
@@ -1,0 +1,44 @@
+package com.legacyminecraft.poseidon.level;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ChunkCompressionType {
+    NONE("none", 0),
+    GZIP("gzip", 1),
+    DEFLATE("deflate", 2);
+
+    private static final Map<String, ChunkCompressionType> BY_NAME = new HashMap<>();
+    private static final Map<Integer, ChunkCompressionType> BY_ID = new HashMap<>();
+
+    static {
+        for(ChunkCompressionType type : values()) {
+            BY_NAME.put(type.name, type);
+            BY_ID.put(type.id, type);
+        }
+    }
+
+    private final String name;
+    private final int id;
+
+    ChunkCompressionType(String name, int id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public static ChunkCompressionType fromName(String name) {
+        return BY_NAME.get(name);
+    }
+
+    public static ChunkCompressionType fromId(int id) {
+        return BY_ID.get(id);
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/net/minecraft/server/RegionFile.java
+++ b/src/main/java/net/minecraft/server/RegionFile.java
@@ -1,5 +1,7 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
+
 import java.io.*;
 import java.util.ArrayList;
 import java.util.zip.DeflaterOutputStream;
@@ -89,7 +91,13 @@ public class RegionFile {
         return i;
     }
 
-    private void a(String s) {}
+    private void a(String s) {
+        // Poseidon start - Allow printing region debug information. Useful for developers (and nerds).
+        if(PoseidonConfig.getInstance().getConfigBoolean("developer.region-transaction-logs.enable", false)) {
+            MinecraftServer.log.info(s);
+        }
+        // Poseidon end
+    }
 
     private void b(String s) {
         this.a(s + "\n");


### PR DESCRIPTION
This pull request is intended to backport some of the improvement made to chunk compression in newer updates and also introduce some new ones.

**Todo List**:
- [x] Allow setting the world compression type (backport from 24w04a).
- [x] Allow disabling world compression.
- [ ] Add `lz4` support (backport from 24w04a).
- [ ] Add `zstd` support.
- [ ] Allow switching block ordering from `XZY` to `YZX` (backport from Anvil).
- [ ] Add support for immediately resaving chunks with these changes applied.

I've also generated (unscientific) benchmarks by regenerating a world with the same seed, immediately exiting the server, and marking down the file size generated by each compression type.

**Unscientific Benchmarks**:
| **Format** | **Compression Ratio** |
|------------|-----------------------|
| none       | 1                     |
| gzip       | ~0.0539               |
| deflate    | ~0.0533               |