### PR TITLE
Fix Watchdog not being disableable

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
@@ -72,7 +72,7 @@ public final class PoseidonServer {
 
         //Start Watchdog
         watchDogThread = new WatchDogThread(Thread.currentThread());
-        if (PoseidonConfig.getInstance().getBoolean("settings.enable-watchdog", true)) {
+        if (PoseidonConfig.getInstance().getBoolean("settings.watchdog.enable", true)) {
             getLogger().info("[Poseidon] Starting Watchdog to detect any server hangs!");
             watchDogThread.start();
             watchDogThread.tickUpdate();


### PR DESCRIPTION
Currently Watchdog cannot be disabled because the config key being checked is `settings.enable-watchdog` instead of `settings.watchdog.enable`.