### PR TITLE
Use HttpURLConnection from java.net instead of HttpsURLConnection during player authentication

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/util/SessionAPI.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/SessionAPI.java
@@ -3,9 +3,9 @@ package com.legacyminecraft.poseidon.util;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
-import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
 
 /**
@@ -57,7 +57,7 @@ public class SessionAPI
         try
         {
             URL obj = new URL(url);
-            HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+            HttpURLConnection con = (HttpURLConnection) obj.openConnection();
             con.setRequestMethod("GET");
             con.setRequestProperty("User-Agent", "Project-Poseidon/0");
             BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));


### PR DESCRIPTION
This pull request changes the class that the `URLConnection` object, used during the fetching of player information during login in `SessionAPI#httpGetRequest`, is casted to, to `java.net.HttpURLConnection`. This is done to allow compatibility with a [ViaProxyAuthHook](https://github.com/ViaVersionAddons/ViaProxyAuthHook) setup, which hijacks the request URL to redirect the authentication to the ViaProxy server, which uses an http request instead of an https request. Both the original class being used for the cast, and `sun.net.www.protocol.http.HttpURLConnection` share `java.netHttpURLConnection` as a superclass, so this should still be a safe cast.