### PR TITLE
Add durability checks to the ItemStack.equals function

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -192,7 +192,11 @@ public class ItemStack {
 
         ItemStack item = (ItemStack) obj;
 
-        return item.getAmount() == getAmount() && item.getTypeId() == getTypeId();
+        return (
+            item.getAmount() == getAmount() &&
+            item.getTypeId() == getTypeId() &&
+            item.getDurability() == getDurability()
+        );
     }
 
     @Override

--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -210,6 +210,8 @@ public class ItemStack {
 
         hash = hash * 19 + 7 * getTypeId(); // Overriding hashCode since equals is overridden, it's just
         hash = hash * 7 + 23 * getAmount(); // too bad these are mutable values... Q_Q
+        hash = hash * 13 + 3 * getDurability();
+
         return hash;
     }
 }


### PR DESCRIPTION
This fixes a bug where ItemStack.Equals does not check for durability