### PR TITLE
Slime entity tags

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
@@ -2,6 +2,7 @@ package org.bukkit.craftbukkit.entity;
 
 import net.minecraft.server.EntitySlime;
 import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Slime;
 
 public class CraftSlime extends CraftLivingEntity implements Slime {
@@ -25,5 +26,15 @@ public class CraftSlime extends CraftLivingEntity implements Slime {
 
     public void setSize(int size) {
         getHandle().setSize(size);
+    }
+
+    @Override
+    public void setTarget(LivingEntity target) {
+
+    }
+
+    @Override
+    public LivingEntity getTarget() {
+        return null;
     }
 }

--- a/src/main/java/org/bukkit/entity/Slime.java
+++ b/src/main/java/org/bukkit/entity/Slime.java
@@ -9,7 +9,7 @@ package org.bukkit.entity;
  * @author Cogito
  *
  */
-public interface Slime extends LivingEntity {
+public interface Slime extends LivingEntity, Monster {
 
     /**
      * @author Celtic Minstrel


### PR DESCRIPTION
Brings slime entity tags in line with other hostile monsters for functions that rely on the _Monster_ tag.

