### PR TITLE
Fix redstone torches updating redstone incorrectly when broken

### DIFF
--- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
@@ -1,6 +1,5 @@
 package net.minecraft.server;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.event.block.BlockRedstoneEvent;
 
 import java.util.ArrayList;
@@ -63,7 +62,7 @@ public class BlockRedstoneTorch extends BlockTorch {
     }
 
     public void remove(World world, int i, int j, int k) {
-        if (this.isOn && (!PoseidonConfig.getInstance().getConfigBoolean("world.settings.pistons.transmutation-fix.enabled", true) || world.getTypeId(i, j, k) == this.id || world.getTypeId(i, j, k) == 75)) {
+        if (this.isOn) {
             world.applyPhysics(i, j - 1, k, this.id);
             world.applyPhysics(i, j + 1, k, this.id);
             world.applyPhysics(i - 1, j, k, this.id);


### PR DESCRIPTION
Fixes a bug introduced by #109 where breaking a redstone torch does not update redstone correctly. This change does however cause an attempt at Moving Piston Merge Transmutation to consume one of the blocks.

**Before:**

https://github.com/user-attachments/assets/fe32543d-2728-415b-8cc5-74c0a27b8337

**After:**

https://github.com/user-attachments/assets/b4e14b44-77ab-4406-977f-29f68ca0674e

