### PR TITLE
Add UUID support to Tamed Wolves

### DIFF
--- a/src/main/java/net/minecraft/server/EntityHuman.java
+++ b/src/main/java/net/minecraft/server/EntityHuman.java
@@ -15,6 +15,9 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 
 import java.util.Iterator;
 import java.util.List;
+//Poseidon start
+import java.util.UUID;
+//Poseidon end
 
 // CraftBukkit start
 // CraftBukkit end
@@ -43,6 +46,9 @@ public abstract class EntityHuman extends EntityLiving {
     public boolean fauxSleeping;
     public String spawnWorld = "";
     // CraftBukkit end
+    // Poseidon start
+    protected UUID uniqueId;
+    // Poseidon end
     public ChunkCoordinates A;
     public int sleepTicks; // CraftBukkit - private -> public
     public float B;
@@ -913,4 +919,13 @@ public abstract class EntityHuman extends EntityLiving {
             this.E = true;
         }
     }
+
+    //Poseidon start
+    public UUID getUniqueId() {
+        if (this.uniqueId == null) {
+            this.uniqueId = UUID.nameUUIDFromBytes(this.name.getBytes());
+        }
+        return this.uniqueId;
+    }
+    //Poseidon end
 }


### PR DESCRIPTION
Adds UUIDs to tamed wolf NBT's I believe I got everything to work correctly. Debug code were commented out. 

Saving and loading nbt data have been modified to use and load a UUID if a name is found but no UUID is attached.

Line 552 in EntityWolf.java `this.datawatcher.watch(16, (byte)(b0 & ~4));` has its byte changed from 5 to 4 because from my understanding setTamed would result in tamed flag (4) being removed and could be a pain point in the future.