### PR TITLE
Support non-Mojang auth URLs

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/util/SessionAPI.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/SessionAPI.java
@@ -33,7 +33,7 @@ public class SessionAPI
         {
             boolean checkIP = ip == "127.0.0.1" || ip == "localhost";
             StringBuilder sb = new StringBuilder();
-            sb.append("https://sessionserver.mojang.com/session/minecraft/hasJoined");
+            sb.append(System.getProperty("minecraft.api.session.host", "https://sessionserver.mojang.com") + "/minecraft/hasJoined");
             sb.append("?username=" + username);
             sb.append("&serverId=" + serverId);
             if (checkIP)


### PR DESCRIPTION
In modern versions of Minecraft (post 1.16), a few system props can be used to override Mojang's backend servers with another URL. This line prevents Poseidon from correctly authenticating with unofficial authentication servers. So, we respect the system property and all is well.