### PR TITLE
Update checker improvements (I hope)

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -204,6 +204,8 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("settings.update-checker.notify-staff.info", "This setting notifies operators and players with the permission poseidon.update when a new version of Poseidon is available on join.");
         generateConfigOption("settings.update-checker.notify-if-up-to-date.enabled", false);
         generateConfigOption("settings.update-checker.notify-if-up-to-date.info", "This setting controls if the update checker will print a message in console if the server is up to date.");
+        generateConfigOption("settings.update-checker.interval.ticks", 20 * 60 * 60);
+        generateConfigOption("settings.update-checker.interval.info", "Controls how often the update checker will query the latest Poseidon version");
 
         //Messages
         generateConfigOption("message.kick.banned", "You are banned from this server!");

--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -202,6 +202,8 @@ public class PoseidonConfig extends Configuration {
         generateConfigOption("settings.update-checker.info", "This setting allows you to disable the update checker. This is useful if you have a custom build of Poseidon or don't want to be notified of updates.");
         generateConfigOption("settings.update-checker.notify-staff.enabled", true);
         generateConfigOption("settings.update-checker.notify-staff.info", "This setting notifies operators and players with the permission poseidon.update when a new version of Poseidon is available on join.");
+        generateConfigOption("settings.update-checker.notify-if-up-to-date.enabled", false);
+        generateConfigOption("settings.update-checker.notify-if-up-to-date.info", "This setting controls if the update checker will print a message in console if the server is up to date.");
 
         //Messages
         generateConfigOption("message.kick.banned", "You are banned from this server!");

--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
@@ -104,7 +104,7 @@ public final class PoseidonServer {
 
         getLogger().info("[Poseidon] Version checker enabled. The server will check for updates every hour.");
         // Run the version checker in a separate thread every hour
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(new PoseidonPlugin(), new Runnable() {
+        Bukkit.getScheduler().scheduleAsyncRepeatingTask(new PoseidonPlugin(), new Runnable() {
             @Override
             public void run() {
                 poseidonVersionChecker.fetchLatestVersion();
@@ -117,7 +117,7 @@ public final class PoseidonServer {
 //            throw new UnsupportedOperationException("Server not initialized");
             return;
         }
-      
+
         getLogger().info("[Poseidon] Stopping Project Poseidon Modules!");
 
         UUIDManager.getInstance().saveJsonArray();

--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonServer.java
@@ -109,7 +109,7 @@ public final class PoseidonServer {
             public void run() {
                 poseidonVersionChecker.fetchLatestVersion();
             }
-        }, 0, 20 * 60 * 60);
+        }, 0, PoseidonConfig.getInstance().getConfigLong("settings.update-checker.interval.ticks"));
     }
 
     public void shutdownServer() {

--- a/src/main/java/com/legacyminecraft/poseidon/utility/PoseidonVersionChecker.java
+++ b/src/main/java/com/legacyminecraft/poseidon/utility/PoseidonVersionChecker.java
@@ -1,5 +1,6 @@
 package com.legacyminecraft.poseidon.utility;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.craftbukkit.CraftServer;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -73,7 +74,8 @@ public class PoseidonVersionChecker {
                 server.getLogger().log(Level.INFO, "[Poseidon] You are currently running version: " + currentVersion);
                 server.getLogger().log(Level.INFO, "[Poseidon] Download the latest version here: " + releaseUrl);
             } else {
-                server.getLogger().log(Level.INFO, "[Poseidon] You are running the latest version (" + currentVersion + ") of Project Poseidon.");
+                if (PoseidonConfig.getInstance().getConfigBoolean("settings.update-checker.notify-if-up-to-date.enabled"))
+                    server.getLogger().log(Level.INFO, "[Poseidon] You are running the latest version (" + currentVersion + ") of Project Poseidon.");
             }
         } catch (Exception e) {
             server.getLogger().log(Level.WARNING, "[Poseidon] Failed to check GitHub for latest version.", e);


### PR DESCRIPTION
Explanation for changes:
- Schedule update check async instead of sync
   - I assume this was the original intention, going by the comment above the scheduler call, but for whatever reason the synchronous version of this method was called instead of the presumably correct asynchronous one. Using the asynchronous method doesn't seem to cause any problems in my testing, whereas with the synchronous method would cause the performance monitor to print a warn to console. Anyhow, I doubt you want to be waiting for the result of a HTTP request on the main thread...
- Add a config option to toggle up to date messages
  - By default, I have disabled printing the "You are running the latest version" message. I find this clutters up logs if you run a server with multiple hours of inactivity and empty logs (like mine). Personally speaking, I would prefer my logs empty. As a thought experiment, let's say that a server has been running continuously ever since the last update (July 22), which as of writing was 33 days ago. That means there would be 792 "You are running the latest version" messages in logs, give or take.
 - Add a config option to control update checker interval
    -  I personally don't find much value in checking for updates once every 24 hours, but for a larger public server with potentially malicious players I understand checking for updates once every 1 hour, so I've left the default interval untouched.


I don't mind changing the config options to their previous default behaviour if you think that would be better :smiley: 